### PR TITLE
fix: allow capabilities command to run without credentials

### DIFF
--- a/cmd/baton-avalara/main.go
+++ b/cmd/baton-avalara/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/conductorone/baton-avalara/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
 	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -24,6 +25,7 @@ func main() {
 		"baton-avalara",
 		getConnector,
 		cfg.Config,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Avalara{}),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())


### PR DESCRIPTION
## Summary

Follow-up to #13 (SDK upgrade PR).

After the SDK upgrade, the `Generate connector capabilities` workflow on main started failing because the required username/password flags prevented the capabilities command from running without credentials.

This fix adds `connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Avalara{})` to provide a default connector instance for the capabilities command.

## Test plan

- [x] `./baton-avalara capabilities` works without credentials
- [ ] CI passes