### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-avalara/main.go
+++ b/cmd/baton-avalara/main.go
@@ -48,7 +48,7 @@ func getConnector(ctx context.Context, c *cfg.Avalara) (types.ConnectorServer, e
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, c.Environment, c.Username, c.Password)
+	cb, err := connector.New(ctx, c.Environment, c.BaseUrl, c.Username, c.Password)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -76,7 +76,7 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Log the decoded credentials for debugging.
-		log.Printf("Decoded credentials: %s", string(payload))
+		log.Printf("Decoded credentials: %s", string(payload)) //nolint:gosec // G706: test-server only, debug logging of test credentials
 
 		pair := strings.SplitN(string(payload), ":", 2)
 		if len(pair) != 2 || pair[0] != "testuser" || pair[1] != "testpass" {
@@ -93,7 +93,7 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		log.Printf("Authentication successful for user: %s", pair[0])
+		log.Printf("Authentication successful for user: %s", pair[0]) //nolint:gosec // G706: test-server only, debug logging
 		next.ServeHTTP(w, r)
 	}
 }
@@ -417,9 +417,9 @@ func sendJSONResponse(w http.ResponseWriter, data interface{}) {
 }
 
 func logRequest(endpoint string, r *http.Request) {
-	log.Printf("Endpoint called: %s\n", endpoint)
-	log.Printf("  Method: %s\n", r.Method)
-	log.Printf("  Query parameters: %s\n", r.URL.RawQuery)
+	log.Printf("Endpoint called: %s\n", endpoint)         //nolint:gosec // G706: test-server only, debug logging
+	log.Printf("  Method: %s\n", r.Method)                //nolint:gosec // G706: test-server only, debug logging
+	log.Printf("  Query parameters: %s\n", r.URL.RawQuery) //nolint:gosec // G706: test-server only, debug logging
 
 	// Log headers.
 	log.Println("  Headers:")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,9 +44,11 @@ type PaginatedResponse interface {
 }
 
 // NewAvalaraClient creates a new instance of AvalaraClient.
-func NewAvalaraClient(environment string, httpClient *uhttp.BaseHttpClient) *AvalaraClient {
+func NewAvalaraClient(environment, baseURLOverride string, httpClient *uhttp.BaseHttpClient) *AvalaraClient {
 	var baseURL string
-	if strings.HasPrefix(strings.ToLower(environment), "http") {
+	if baseURLOverride != "" {
+		baseURL = baseURLOverride
+	} else if strings.HasPrefix(strings.ToLower(environment), "http") {
 		baseURL = environment
 	} else {
 		switch environment {
@@ -340,7 +342,7 @@ func (c *AvalaraClient) Ping(ctx context.Context) (*PingResponse, error) {
 }
 
 // GetAvalaraClient creates and returns a configured AvalaraClient.
-func GetAvalaraClient(ctx context.Context, environment, username, password string) (*AvalaraClient, error) {
+func GetAvalaraClient(ctx context.Context, environment, baseURL, username, password string) (*AvalaraClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)
@@ -348,7 +350,7 @@ func GetAvalaraClient(ctx context.Context, environment, username, password strin
 
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
 
-	client := NewAvalaraClient(environment, baseHttpClient)
+	client := NewAvalaraClient(environment, baseURL, baseHttpClient)
 	client.AddCredentials(username, password)
 	return client, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -46,11 +46,12 @@ type PaginatedResponse interface {
 // NewAvalaraClient creates a new instance of AvalaraClient.
 func NewAvalaraClient(environment, baseURLOverride string, httpClient *uhttp.BaseHttpClient) *AvalaraClient {
 	var baseURL string
-	if baseURLOverride != "" {
+	switch {
+	case baseURLOverride != "":
 		baseURL = baseURLOverride
-	} else if strings.HasPrefix(strings.ToLower(environment), "http") {
+	case strings.HasPrefix(strings.ToLower(environment), "http"):
 		baseURL = environment
-	} else {
+	default:
 		switch environment {
 		case "sandbox":
 			baseURL = SandboxBaseURL

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -35,26 +35,26 @@ func newTestClient(response *http.Response, err error) *AvalaraClient {
 	transport := &testRoundTripper{response: response, err: err}
 	httpClient := &http.Client{Transport: transport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
-	return NewAvalaraClient("", baseHttpClient)
+	return NewAvalaraClient("", "", baseHttpClient)
 }
 
 func TestNewAvalaraClient(t *testing.T) {
 	t.Run("Production environment", func(t *testing.T) {
-		client := NewAvalaraClient("", nil)
+		client := NewAvalaraClient("", "", nil)
 		if client.baseURL != ProductionBaseURL {
 			t.Errorf("Expected baseURL to be %s, got %s", ProductionBaseURL, client.baseURL)
 		}
 	})
 
 	t.Run("Sandbox environment", func(t *testing.T) {
-		client := NewAvalaraClient("sandbox", nil)
+		client := NewAvalaraClient("sandbox", "", nil)
 		if client.baseURL != SandboxBaseURL {
 			t.Errorf("Expected baseURL to be %s, got %s", SandboxBaseURL, client.baseURL)
 		}
 	})
 
 	t.Run("Client header", func(t *testing.T) {
-		client := NewAvalaraClient("", nil)
+		client := NewAvalaraClient("", "", nil)
 		expectedPrefix := "baton-avalara; 1.0.0; Go SDK; API_VERSION"
 		if !strings.HasPrefix(client.clientHeader, expectedPrefix) {
 			t.Errorf("Expected clientHeader to start with %s, got %s", expectedPrefix, client.clientHeader)
@@ -64,7 +64,7 @@ func TestNewAvalaraClient(t *testing.T) {
 
 func TestAvalaraClient_AddCredentials(t *testing.T) {
 	// Create a new AvalaraClient.
-	client := NewAvalaraClient("", nil)
+	client := NewAvalaraClient("", "", nil)
 
 	// Test credentials.
 	username := "testuser"
@@ -243,7 +243,7 @@ func TestAvalaraClient_GetUserRoles_RequestDetails(t *testing.T) {
 	// Create a test client with the mock transport.
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
-	client := NewAvalaraClient("sandbox", baseHttpClient)
+	client := NewAvalaraClient("sandbox", "", baseHttpClient)
 	client.AddCredentials("testuser", "testpass")
 
 	// Call GetUserRoles with nextLink.
@@ -673,7 +673,7 @@ func TestAvalaraClient_GetPermissions_RequestDetails(t *testing.T) {
 	// Create a test client with the mock transport.
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
-	client := NewAvalaraClient("sandbox", baseHttpClient)
+	client := NewAvalaraClient("sandbox", "", baseHttpClient)
 	client.AddCredentials("testuser", "testpass")
 
 	// Call GetPermissions.
@@ -874,7 +874,7 @@ func TestAvalaraClient_GetUserEntitlements_RequestDetails(t *testing.T) {
 	// Create a test client with the mock transport.
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
-	client := NewAvalaraClient("sandbox", baseHttpClient)
+	client := NewAvalaraClient("sandbox", "", baseHttpClient)
 	client.AddCredentials("testuser", "testpass")
 
 	// Call GetUserEntitlements.
@@ -952,7 +952,7 @@ func TestGetAvalaraClient(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := GetAvalaraClient(ctx, tc.environment, tc.username, tc.password)
+			client, err := GetAvalaraClient(ctx, tc.environment, "", tc.username, tc.password)
 
 			// Check for errors.
 			if err != nil {
@@ -1146,7 +1146,7 @@ func TestAvalaraClient_Ping_RequestDetails(t *testing.T) {
 	// Create a test client with the mock transport.
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
-	client := NewAvalaraClient("sandbox", baseHttpClient)
+	client := NewAvalaraClient("sandbox", "", baseHttpClient)
 	client.AddCredentials("testuser", "testpass")
 
 	// Call Ping.

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Avalara struct {
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	Environment string `mapstructure:"environment"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Avalara) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,10 @@ var (
 		field.WithDescription("The Avalara environment to connect to (production or sandbox)"),
 		field.WithDefaultValue("production"),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Avalara API URL (for testing)"),
+	)
 
 	FieldRelationships = []field.SchemaFieldRelationship{
 		field.FieldsRequiredTogether(
@@ -35,6 +39,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	UsernameField,
 	PasswordField,
 	EnvironmentField,
+	BaseURLField,
 }, field.WithConstraints(FieldRelationships...))
 
 func ValidateConfig(cfg *Avalara) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Avalara API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	FieldRelationships = []field.SchemaFieldRelationship{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Avalara API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	FieldRelationships = []field.SchemaFieldRelationship{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -58,9 +58,10 @@ func (d *Avalara) Validate(ctx context.Context) (annotations.Annotations, error)
 func New(
 	ctx context.Context,
 	environment string,
+	baseURL string,
 	username, password string,
 ) (*Avalara, error) {
-	client, err := avalaraclient.GetAvalaraClient(ctx, environment, username, password)
+	client, err := avalaraclient.GetAvalaraClient(ctx, environment, baseURL, username, password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-avalara/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-avalara --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable base URL override for the Avalara API client, letting users point the integration to a custom endpoint while preserving environment-based defaults when not set.

* **Configuration**
  * Introduced a new (CLI-only, hidden) configuration option to supply the base URL for testing or custom endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->