### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up an Avalara connector"
-description: "C1 provides identity governance and just-in-time provisioning for Avalara. Integrate your Avalara instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Avalara. Integrate your Avalara instance with C1 for unified visibility and governance over user access."
 og:title: "Set up an Avalara connector"
-og:description: "C1 provides identity governance and just-in-time provisioning for Avalara. Integrate your Avalara instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance for Avalara. Integrate your Avalara instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Avalara"
 ---
 
@@ -26,7 +26,7 @@ Configuring the connector requires you to pass in credentials generated in Avala
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Avalara connector
 
@@ -79,7 +79,7 @@ Configuring the connector requires you to pass in credentials generated in Avala
     </Step>
 </Steps>
 
-**That's it!** Your Avalara connector is now pulling access data into C1.
+**Done.** Your Avalara connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Avalara connector, hosted and run in your own environment.**
@@ -192,7 +192,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Avalara connector is now pulling access data into C1.
+**Done.** Your Avalara connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines