### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -171,7 +171,7 @@ spec:
     spec:
       containers:
       - name: baton-avalara
-        image: ghcr.io/conductorone/baton-avalara:latest
+        image: public.ecr.aws/conductorone/baton-avalara:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -195,5 +195,3 @@ spec:
 **Done.** Your Avalara connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._